### PR TITLE
Develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ obj/
 /packages/
 riderModule.iml
 /_ReSharper.Caches/
+.vs/

--- a/LauncherConfig.cs
+++ b/LauncherConfig.cs
@@ -19,6 +19,8 @@ namespace ObsidianLauncher
         public string AdoptiumDownloadsDir { get; }
         public string LogsDir { get; }
 
+        public static readonly string VERSION = "1.0"; // Version of the launcher
+
         private readonly ILogger _logger = Log.ForContext<LauncherConfig>(); // Instance logger
 
         public LauncherConfig(string baseDataDir = ".ObsidianLauncher")

--- a/Obsidian Launcher.csproj
+++ b/Obsidian Launcher.csproj
@@ -13,5 +13,13 @@
       <PackageReference Include="Serilog.Sinks.Console" Version="6.0.1-dev-00953" />
       <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     </ItemGroup>
+	
+	<PropertyGroup>
+  <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+  <SelfContained>true</SelfContained>
+  <PublishSingleFile>true</PublishSingleFile>
+  <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
+</PropertyGroup>
+
 
 </Project>

--- a/Program.cs
+++ b/Program.cs
@@ -45,7 +45,8 @@ public class Program
         }
 
         Log.Information("==================================================");
-        Log.Information("  Obsidian Minecraft Launcher (C# Port) v0.1");
+        Log.Information("  Obsidian Launcher v{Version}",
+            LauncherConfig.VERSION);
         Log.Information("==================================================");
         Log.Information("Data directory: {BaseDataPath}", launcherConfig.BaseDataPath);
         Log.Information("Log directory: {LogsDir}", launcherConfig.LogsDir);
@@ -265,7 +266,7 @@ public class Program
                 }
             }
 
-            Log.Information("Minecraft Launcher (C# Port) has completed its operation for version {VersionId}.", minecraftVersion.Id);
+            Log.Information("Obsidian Launcher has completed its operation for version {VersionId}.", minecraftVersion.Id);
         }
         catch (OperationCanceledException)
         {


### PR DESCRIPTION
## Summary by Sourcery

Introduce a static version constant and unify launcher naming in logs

Enhancements:
- Add static VERSION field to LauncherConfig to centralize launcher version
- Update startup banner to use dynamic version and rename to "Obsidian Launcher"
- Change completion log message to consistently reference "Obsidian Launcher"