### PR TITLE
Add test project and fix null safety issues

### DIFF
--- a/Obsidian Launcher.csproj
+++ b/Obsidian Launcher.csproj
@@ -31,4 +31,8 @@
         <AvaloniaResource Include="Images\**" />
     </ItemGroup>
 
+    <ItemGroup>
+        <Compile Remove="Tests\**" />
+    </ItemGroup>
+
 </Project>

--- a/Obsidian Launcher.sln
+++ b/Obsidian Launcher.sln
@@ -2,15 +2,49 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Obsidian Launcher", "Obsidian Launcher.csproj", "{5364BD36-63DC-477E-82C4-D066C25FE5B7}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ObsidianLauncher.Tests", "Tests\ObsidianLauncher.Tests.csproj", "{AB80C01B-3E4F-44CC-9E8B-4CB1AD949097}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{5364BD36-63DC-477E-82C4-D066C25FE5B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5364BD36-63DC-477E-82C4-D066C25FE5B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5364BD36-63DC-477E-82C4-D066C25FE5B7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5364BD36-63DC-477E-82C4-D066C25FE5B7}.Debug|x64.Build.0 = Debug|Any CPU
+		{5364BD36-63DC-477E-82C4-D066C25FE5B7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5364BD36-63DC-477E-82C4-D066C25FE5B7}.Debug|x86.Build.0 = Debug|Any CPU
 		{5364BD36-63DC-477E-82C4-D066C25FE5B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5364BD36-63DC-477E-82C4-D066C25FE5B7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5364BD36-63DC-477E-82C4-D066C25FE5B7}.Release|x64.ActiveCfg = Release|Any CPU
+		{5364BD36-63DC-477E-82C4-D066C25FE5B7}.Release|x64.Build.0 = Release|Any CPU
+		{5364BD36-63DC-477E-82C4-D066C25FE5B7}.Release|x86.ActiveCfg = Release|Any CPU
+		{5364BD36-63DC-477E-82C4-D066C25FE5B7}.Release|x86.Build.0 = Release|Any CPU
+		{AB80C01B-3E4F-44CC-9E8B-4CB1AD949097}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AB80C01B-3E4F-44CC-9E8B-4CB1AD949097}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AB80C01B-3E4F-44CC-9E8B-4CB1AD949097}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AB80C01B-3E4F-44CC-9E8B-4CB1AD949097}.Debug|x64.Build.0 = Debug|Any CPU
+		{AB80C01B-3E4F-44CC-9E8B-4CB1AD949097}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AB80C01B-3E4F-44CC-9E8B-4CB1AD949097}.Debug|x86.Build.0 = Debug|Any CPU
+		{AB80C01B-3E4F-44CC-9E8B-4CB1AD949097}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AB80C01B-3E4F-44CC-9E8B-4CB1AD949097}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AB80C01B-3E4F-44CC-9E8B-4CB1AD949097}.Release|x64.ActiveCfg = Release|Any CPU
+		{AB80C01B-3E4F-44CC-9E8B-4CB1AD949097}.Release|x64.Build.0 = Release|Any CPU
+		{AB80C01B-3E4F-44CC-9E8B-4CB1AD949097}.Release|x86.ActiveCfg = Release|Any CPU
+		{AB80C01B-3E4F-44CC-9E8B-4CB1AD949097}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{AB80C01B-3E4F-44CC-9E8B-4CB1AD949097} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/Services/Import/FtbImporter.cs
+++ b/Services/Import/FtbImporter.cs
@@ -54,8 +54,8 @@ public class FtbImporter
         return result?.Packs?.Select(p => new FtbPackSummary
         {
             Id = p.Id,
-            Name = p.Name,
-            Synopsis = p.Synopsis,
+            Name = p.Name ?? "",
+            Synopsis = p.Synopsis ?? "",
             Installs = p.Installs
         }).ToList() ?? new List<FtbPackSummary>();
     }

--- a/Services/JavaManager.cs
+++ b/Services/JavaManager.cs
@@ -483,6 +483,7 @@ public class JavaManager
     /// Required on Linux/macOS after TAR.GZ extraction since .NET's TarFile does not
     /// preserve Unix file permissions.
     /// </summary>
+    [System.Runtime.Versioning.UnsupportedOSPlatform("windows")]
     private void SetExecutableBitsInBinDirs(string rootDir)
     {
         try

--- a/Services/ModLoaders/ForgeInstaller.cs
+++ b/Services/ModLoaders/ForgeInstaller.cs
@@ -211,7 +211,8 @@ public class ForgeInstaller
         {
             Id = versionInfo.Id ?? fullVersion,
             MainClass = versionInfo.MainClass ?? "net.minecraft.launchwrapper.Launch",
-            InheritsFrom = versionInfo.InheritsFrom
+            InheritsFrom = versionInfo.InheritsFrom,
+            Type = versionInfo.Type ?? "release"
         };
 
         // Convert old-style libraries

--- a/Services/Modrinth/ModManager.cs
+++ b/Services/Modrinth/ModManager.cs
@@ -182,7 +182,7 @@ public class ModManager
     public Task<List<ModrinthVersion>?> GetCompatibleVersionsAsync(
         string projectIdOrSlug,
         string gameVersion,
-        string loader,
+        string? loader,
         CancellationToken ct = default)
     {
         return _client.GetProjectVersionsAsync(projectIdOrSlug, gameVersion, loader, ct);

--- a/Utils/BoolToOpacityConverter.cs
+++ b/Utils/BoolToOpacityConverter.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace ObsidianLauncher.Utils;
+
+public class BoolToOpacityConverter : IValueConverter
+{
+    public static readonly BoolToOpacityConverter Instance = new();
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => value is true ? 1.0 : 0.5;
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/ViewModels/CreateInstanceViewModel.cs
+++ b/ViewModels/CreateInstanceViewModel.cs
@@ -36,7 +36,7 @@ public class CreateInstanceViewModel : ViewModelBase
     public event EventHandler? CreationCompleted;
 
     // Designer constructor
-    public CreateInstanceViewModel() : this(null, null) { }
+    public CreateInstanceViewModel() : this((HttpManager?)null, null) { }
 
     public CreateInstanceViewModel(HttpManager? httpManager, InstanceManager? instanceManager = null, LauncherSettings? launcherSettings = null)
     {
@@ -51,11 +51,6 @@ public class CreateInstanceViewModel : ViewModelBase
         CancelCommand = new RelayCommand(() => { });
 
         ModLoaderVersions = new ObservableCollection<string>();
-    }
-
-    public CreateInstanceViewModel(ModLoaderService modLoaderService, LauncherSettings? settings = null) : this()
-    {
-        _launcherSettings = settings;
     }
 
     public string InstanceName

--- a/Views/ModBrowserWindow.axaml
+++ b/Views/ModBrowserWindow.axaml
@@ -1,6 +1,7 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:ObsidianLauncher.ViewModels"
+        xmlns:utils="using:ObsidianLauncher.Utils"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d" d:DesignWidth="950" d:DesignHeight="650"
@@ -174,7 +175,7 @@
                                 <StackPanel Spacing="2" Margin="4,2">
                                     <TextBlock Text="{Binding FileName}" FontSize="11"
                                                TextTrimming="CharacterEllipsis"
-                                               Opacity="{Binding IsEnabled, Converter={x:Static BoolConverters.IsNotNull}}"/>
+                                               Opacity="{Binding IsEnabled, Converter={x:Static utils:BoolToOpacityConverter.Instance}}"/>
                                     <StackPanel Orientation="Horizontal" Spacing="4">
                                         <Button Content="En/Disable"
                                                 CommandParameter="{Binding FileName}"


### PR DESCRIPTION
## Summary
This PR adds a test project infrastructure to the solution and addresses several null safety and code quality issues throughout the codebase.

## Key Changes

- **Test Project Setup**: Added `ObsidianLauncher.Tests` project to the solution with a dedicated Tests folder and proper project configuration
- **Solution Configuration**: Extended build configurations to support x64 and x86 platforms in addition to Any CPU
- **Null Safety Improvements**:
  - Fixed null coalescing in `FtbImporter.cs` to provide empty string defaults for Name and Synopsis
  - Made `loader` parameter nullable in `ModrinthVersion.GetCompatibleVersionsAsync()`
  - Added null coalescing for Type field in `ForgeInstaller.cs` version info
- **UI Converter**: Created `BoolToOpacityConverter` utility class to replace the generic `BoolConverters.IsNotNull` with a more semantic converter that maps boolean values to opacity levels (1.0 for true, 0.5 for false)
- **Code Cleanup**:
  - Removed unused `CreateInstanceViewModel` constructor that took `ModLoaderService` parameter
  - Fixed designer constructor to explicitly cast null to `HttpManager?` for clarity
  - Added `[UnsupportedOSPlatform("windows")]` attribute to `SetExecutableBitsInBinDirs()` method to document platform-specific behavior
  - Excluded Tests directory from main project compilation

## Notable Implementation Details
- The new `BoolToOpacityConverter` is used in `ModBrowserWindow.axaml` to control mod file visibility based on enabled state
- Test project is properly nested under a solution folder for organization
- All platform configurations (x86, x64) map to Any CPU for the main launcher project, maintaining compatibility

https://claude.ai/code/session_01MK9Y1aPZBBdwB8xab4VKPH